### PR TITLE
Add Company Email Validation to Registration Process

### DIFF
--- a/client/src/pages/RegisterPage.js
+++ b/client/src/pages/RegisterPage.js
@@ -18,6 +18,12 @@ const RegisterPage = () => {
     e.preventDefault();
     console.log('Registration started');
 
+    // Check if email is a company email
+    if (!email.endsWith('@aasyp.org')) {
+      setError("Please use a company email address ending with @aasyp.org");
+      return;
+    }
+
     // Check if passwords match
     if (password !== confirmPassword) {
       setError("Passwords don't match");


### PR DESCRIPTION
This pull request introduces a validation step in the registration process to ensure that users register with a company email address ending with '@aasyp.org'. If the email does not meet this requirement, an error message is displayed, and the registration process is halted. This change helps to restrict registration to company employees only.